### PR TITLE
Fix reward rate lookup in analysis

### DIFF
--- a/agents/data_analysis.py
+++ b/agents/data_analysis.py
@@ -2,7 +2,10 @@
 def analyze_snapshot(snapshot):
     results = []
     for provider in snapshot.get("providers", []):
-        reward_rate = provider.get("rewardRate", 0)
+        # `snapshot.py` stores the key as `reward_rate`, so use the same
+        # naming here for analysis. Using the wrong key would cause all
+        # reward rates to default to 0 and skip important checks.
+        reward_rate = provider.get("reward_rate", 0)
         if reward_rate < 0.5:
             results.append({"provider": provider["name"], "status": "Low reward rate", "rate": reward_rate})
         elif reward_rate > 2.5:


### PR DESCRIPTION
## Summary
- fix incorrect key name in `analyze_snapshot`

## Testing
- `python3 -m py_compile agents/data_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6840080f94108321b7f5686f8e871492