### PR TITLE
Improve reward rate chart readability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -275,9 +275,9 @@
 
       Plotly.newPlot('rewardRateChart', [chartData], {
         title: `Reward Rate (%) - ${timeframe}`,
-        xaxis: { title: 'Provider' },
+        xaxis: { title: 'Provider', tickangle: -45 },
         yaxis: { title: 'Reward Rate (%)' },
-        margin: { t: 50, l: 50, r: 50, b: 50 },
+        margin: { t: 50, l: 50, r: 50, b: 120 },
         responsive: true
       });
     }


### PR DESCRIPTION
## Summary
- rotate x-axis labels on reward rate chart
- increase bottom margin for better label visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684012876b348321a5864682e484d1e3