### PR TITLE
Update chart filters & table layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,20 @@
       outline: none; /* Remove default focus outline */
       box-shadow: 0 0 5px #374151; /* Add a subtle shadow for focus */
     }
+
+    /* Table container for scrolling */
+    #tableContainer {
+      max-height: 600px;
+      overflow-y: auto;
+    }
+
+    /* Sticky table headers */
+    #dataTable thead th {
+      position: sticky;
+      top: 0;
+      background-color: #374151; /* Same as bg-gray-700 */
+      z-index: 10;
+    }
   </style>
 </head>
 
@@ -41,35 +55,6 @@
   </header>
 
   <main class="container mx-auto p-4">
-    <!-- Controls -->
-    <section class="flex flex-wrap gap-4 mb-6">
-      <div class="flex-1 min-w-[200px]">
-        <label class="block font-bold mb-2">Max locked voting power (%):</label>
-        <input type="number" id="maxVotePowerInput" min="0" max="100" step="0.1" value="100"
-          class="w-full p-2 bg-gray-800 border border-gray-700 rounded" />
-      </div>
-      <div class="flex-1 min-w-[200px]">
-        <label class="block font-bold mb-2">
-          <input type="checkbox" id="registeredLatestOnly" class="mr-2" />
-          Registered in Latest Snapshot Only
-        </label>
-      </div>
-      <div class="flex-1 min-w-[200px]">
-        <label class="block font-bold mb-2">
-          <input type="checkbox" id="registeredOnly" class="mr-2" />
-          Registered at Each Date
-        </label>
-      </div>
-      <div class="flex-1 min-w-[200px]">
-        <label for="timeframe" class="block font-bold mb-2">Timeframe:</label>
-        <select id="timeframe" class="w-full p-2 bg-gray-800 border border-gray-700 rounded">
-          <option value="latest">Latest</option>
-          <option value="7-day">7-Day Average</option>
-          <option value="30-day">30-Day Average</option>
-          <option value="cumulative">Cumulative Average</option>
-        </select>
-      </div>
-    </section>
 
     <section id="providerSection" class="border-4 border-gray-700 rounded p-4 mb-4">
       <div class="mb-4">
@@ -81,22 +66,48 @@
       <div id="singleChartContainer" style="width: 100%;"></div>
     </section>
 
-    <!-- Reward Rate Chart -->
-    <section id="chartContainer" class="overflow-x-auto mb-4 border-4 border-gray-700 rounded p-4">
-      <canvas id="rewardRateChart" class="w-full h-[400px]"></canvas>
-    </section>
+    <!-- Multi-provider chart and table -->
+    <section id="multiContainer" class="border-4 border-gray-700 rounded p-4 mb-4">
+      <div id="filtersSection" class="flex flex-wrap gap-4 mb-6">
+        <div class="flex-1 min-w-[200px]">
+          <label class="block font-bold mb-2">Max locked voting power (%):</label>
+          <input type="number" id="maxVotePowerInput" min="0" max="100" step="0.1" value="100"
+            class="w-full p-2 bg-gray-800 border border-gray-700 rounded" />
+        </div>
+        <div class="flex-1 min-w-[200px]">
+          <label class="block font-bold mb-2">
+            <input type="checkbox" id="registeredLatestOnly" class="mr-2" />
+            Registered in Latest Snapshot Only
+          </label>
+        </div>
+        <div class="flex-1 min-w-[200px]">
+          <label class="block font-bold mb-2">
+            <input type="checkbox" id="registeredOnly" class="mr-2" />
+            Registered at Each Date
+          </label>
+        </div>
+        <div class="flex-1 min-w-[200px]">
+          <label for="timeframe" class="block font-bold mb-2">Timeframe:</label>
+          <select id="timeframe" class="w-full p-2 bg-gray-800 border border-gray-700 rounded">
+            <option value="latest">Latest</option>
+            <option value="7-day">7-Day Average</option>
+            <option value="30-day">30-Day Average</option>
+            <option value="cumulative">Cumulative Average</option>
+          </select>
+        </div>
+      </div>
 
-    <div id="miniChartsContainer" style="overflow-y: auto; max-height: 1200px; width: 100%;">
-      <!-- Mini charts will be injected here -->
-    </div>
+      <!-- Reward Rate Chart -->
+      <div id="chartContainer" class="overflow-x-auto mb-4">
+        <canvas id="rewardRateChart" class="w-full h-[400px]"></canvas>
+      </div>
 
-    <!-- Full Data Table -->
-    <section>
       <h2 class="text-xl font-bold mt-6">Full Data Table</h2>
-      <table id="dataTable" class="display w-full border-collapse mt-4 bg-gray-800 text-gray-100">
-        <thead>
-          <tr class="bg-gray-700">
-            <th class="p-2 border border-gray-600">Date</th>
+      <div id="tableContainer" class="overflow-y-auto max-h-[600px]">
+        <table id="dataTable" class="display w-full border-collapse mt-4 bg-gray-800 text-gray-100">
+          <thead>
+            <tr class="bg-gray-700">
+              <th class="p-2 border border-gray-600">Date</th>
             <th class="p-2 border border-gray-600">Provider</th>
             <th class="p-2 border border-gray-600">Current Voting Power %</th>
             <th class="p-2 border border-gray-600">Locked Voting Power %</th>
@@ -111,8 +122,13 @@
         <tbody>
           <!-- Rows will be dynamically populated by renderTable() -->
         </tbody>
-      </table>
+        </table>
+      </div>
     </section>
+
+    <div id="miniChartsContainer" style="overflow-y: auto; max-height: 1200px; width: 100%;">
+      <!-- Mini charts will be injected here -->
+    </div>
   </main>
 
   <script>
@@ -364,6 +380,9 @@
           ordering: true,
           order: [[0, 'desc'], [1, 'asc']],
           pageLength: 100,
+          scrollY: '500px',
+          scrollX: true,
+          scrollCollapse: true,
           columnDefs: [
             { targets: 0, type: 'date' },
             { targets: [2,3,4,5,6,7,8,9], type: 'num' },


### PR DESCRIPTION
## Summary
- move reward filters next to the multi-provider reward rate chart
- wrap chart and table in a single bordered section
- keep table headers visible with sticky CSS
- make table scrollable and configure DataTables to use a scrolling region

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684092f186cc832180309002308b198a