### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,10 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.4.1/css/responsive.dataTables.min.css">
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/responsive/2.4.1/js/dataTables.responsive.min.js"></script>
   <style>
     /* Style the DataTables dropdown */
     .dataTables_length select {
@@ -34,7 +36,7 @@
 
     /* Table container for scrolling */
     #tableContainer {
-      max-height: 600px;
+      max-height: 80vh;
       overflow-y: auto;
     }
 
@@ -68,7 +70,7 @@
 
     <!-- Multi-provider chart and table -->
     <section id="multiContainer" class="border-4 border-gray-700 rounded p-4 mb-4">
-      <div id="filtersSection" class="flex flex-wrap gap-4 mb-6">
+      <div id="filtersSection" class="flex flex-col sm:flex-row flex-wrap gap-4 mb-6">
         <div class="flex-1 min-w-[200px]">
           <label class="block font-bold mb-2">Max locked voting power (%):</label>
           <input type="number" id="maxVotePowerInput" min="0" max="100" step="0.1" value="100"
@@ -99,11 +101,11 @@
 
       <!-- Reward Rate Chart -->
       <div id="chartContainer" class="overflow-x-auto mb-4">
-        <canvas id="rewardRateChart" class="w-full h-[400px]"></canvas>
+        <canvas id="rewardRateChart" class="w-full h-[200px] md:h-[400px]"></canvas>
       </div>
 
       <h2 class="text-xl font-bold mt-6">Full Data Table</h2>
-      <div id="tableContainer" class="overflow-y-auto max-h-[600px]">
+      <div id="tableContainer" class="overflow-y-auto max-h-[80vh]">
         <table id="dataTable" class="display w-full border-collapse mt-4 bg-gray-800 text-gray-100">
           <thead>
             <tr class="bg-gray-700">
@@ -126,7 +128,7 @@
       </div>
     </section>
 
-    <div id="miniChartsContainer" style="overflow-y: auto; max-height: 1200px; width: 100%;">
+    <div id="miniChartsContainer" style="overflow-y: auto; max-height: 80vh; width: 100%;">
       <!-- Mini charts will be injected here -->
     </div>
   </main>
@@ -302,6 +304,7 @@
         },
         options: {
           responsive: true,
+          maintainAspectRatio: false,
           plugins: {
             title: { display: true, text: `Flare Reward Rate - ${timeframe}` },
             legend: { display: false }
@@ -378,10 +381,10 @@
           paging: true,
           searching: true,
           ordering: true,
+          responsive: true,
           order: [[0, 'desc'], [1, 'asc']],
           pageLength: 100,
-          scrollY: '500px',
-          scrollX: true,
+          scrollY: '50vh',
           scrollCollapse: true,
           columnDefs: [
             { targets: 0, type: 'date' },
@@ -505,7 +508,8 @@
        },
        options: {
          responsive: true,
-          plugins: {
+         maintainAspectRatio: false,
+         plugins: {
             title: { display: true, text: selectedProvider + ' - Network Voting Power' },
             legend: { position: 'top' }
           },
@@ -526,6 +530,7 @@
         },
         options: {
           responsive: true,
+          maintainAspectRatio: false,
           plugins: {
             title: { display: true, text: selectedProvider + ' - Flare Reward Rate' },
             legend: { display: false }


### PR DESCRIPTION
## Summary
- add DataTables responsive assets
- tweak layout and heights for small screens
- enable responsive DataTables and flexible charts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840951d001c8321a7d1fc0a74f563b4