### PR TITLE
Fix query dashboard instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # flare-ftso-snapshot
 This repo is designed to scrape the FTSO provider rewards data and associated registration information on a daily timeframe so one can make informed decisions about which FTSO providers over times are the best to choose to maximise reward rates and reduce network fees associated with swapping delegations too often
+
+## Querying snapshots with an LLM
+
+Run a small API to query the snapshot data using a lightweight language model.
+
+### Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+### Start the server
+
+```bash
+uvicorn query_server:app --reload
+```
+
+Start the server and visit `http://localhost:8000` in your browser. The dashboard
+is served directly by the API and the prompt bar sends questions to
+`http://localhost:8000/query`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,9 +48,15 @@
 </head>
 
 <body class="bg-gray-900 text-gray-100 font-sans">
-  <header class="text-center py-4 bg-gray-800 border-b border-gray-700 flex items-center justify-center gap-4">
-    <img src="assets/logo.png" alt="Dashboard Logo" class="h-12 w-auto" />
-    <h1 class="text-2xl font-bold">FTSO Flare Dashboard</h1>
+  <header class="py-4 bg-gray-800 border-b border-gray-700 flex items-center justify-between gap-4">
+    <div class="flex items-center gap-4">
+      <img src="assets/logo.png" alt="Dashboard Logo" class="h-12 w-auto" />
+      <h1 class="text-2xl font-bold">FTSO Flare Dashboard</h1>
+    </div>
+    <div id="queryBar" class="flex items-center space-x-2">
+      <input id="queryInput" type="text" placeholder="Ask about snapshots..." class="p-2 bg-gray-700 border border-gray-600 rounded-l text-sm w-64" />
+      <button id="queryButton" class="px-3 py-2 bg-purple-600 text-white rounded-r">Ask</button>
+    </div>
   </header>
 
   <main class="container mx-auto p-4">
@@ -578,6 +584,25 @@
       debouncedRenderTable();
     });
     document.getElementById('timeframe').addEventListener('change', debouncedRenderChart);
+
+    async function sendQuery() {
+      const input = document.getElementById('queryInput');
+      const question = input.value.trim();
+      if (!question) return;
+      try {
+        const res = await fetch('/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question })
+        });
+        const data = await res.json();
+        alert(data.answer);
+      } catch (err) {
+        alert('Failed to query server');
+      }
+    }
+
+    document.getElementById('queryButton').addEventListener('click', sendQuery);
 
     document.addEventListener('DOMContentLoaded', () => {
       loadData().then(() => {

--- a/query_server.py
+++ b/query_server.py
@@ -1,0 +1,36 @@
+import glob
+import json
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from transformers import pipeline
+
+app = FastAPI()
+app.mount("/", StaticFiles(directory="docs", html=True), name="docs")
+
+# Load a lightweight generation model
+text_gen = pipeline("text-generation", model="gpt2")
+
+# Gather snapshot data
+snapshots = []
+for path in sorted(glob.glob("docs/daily_snapshots/*.json")):
+    with open(path) as f:
+        snapshots.append(json.load(f))
+
+# Keep context short to ensure fast inference
+CONTEXT = json.dumps(snapshots)[:2000]
+
+class Question(BaseModel):
+    question: str
+
+@app.post("/query")
+def query(q: Question):
+    prompt = (
+        "Answer this question about the dataset:\n" + CONTEXT +
+        f"\nQuestion: {q.question}\nAnswer:"
+    )
+    result = text_gen(prompt, max_length=len(prompt.split()) + 50, num_return_sequences=1)
+    generated = result[0]["generated_text"]
+    answer = generated[len(prompt):].strip()
+    return {"answer": answer}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@
 requests
 python-dotenv
 pytest
+fastapi
+uvicorn
+transformers
+torch


### PR DESCRIPTION
## Summary
- serve docs via FastAPI so `/query` is reachable from the page
- clarify README usage instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68409af341d48321856cddbd2f6e2459