### PR TITLE
Fix automatic vote power snapshots

### DIFF
--- a/.github/workflows/current-vote-power.yml
+++ b/.github/workflows/current-vote-power.yml
@@ -1,0 +1,37 @@
+name: Current Vote Power Snapshot
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+jobs:
+  run-current-vp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser chromium-chromedriver
+          pip install selenium beautifulsoup4 bs4
+
+      - name: Run current vote power script
+        run: python current_vote_power.py
+
+      - name: Commit and push results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@users.noreply.github.com'
+          git add current_vote_power/ docs/current_vote_power/
+          git commit -m "Update current vote power snapshots" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Execute the test suite with `pytest`:
 ```bash
 pytest
 ```
+
+## Automated Vote Power Snapshots
+
+GitHub Actions runs `current_vote_power.py` every ten minutes to keep
+`current_vote_power/` and `docs/current_vote_power/` up to date with the latest
+Flare and Songbird vote power data.
 =======
 ## License
 


### PR DESCRIPTION
## Summary
- add workflow to capture vote power every 10 minutes
- document automated vote power snapshots
- keep an empty directory for new vote power files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417474bc5083219e82e843188f13ce