### PR TITLE
Fix snapshot loading

### DIFF
--- a/query_server.py
+++ b/query_server.py
@@ -1,5 +1,6 @@
 import glob
 import json
+import os
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
@@ -18,6 +19,8 @@ except Exception as e:
 # Gather snapshot data
 snapshots = []
 for path in sorted(glob.glob("docs/daily_snapshots/*.json")):
+    if os.path.basename(path) == "manifest.json":
+        continue
     try:
         with open(path) as f:
             snapshots.append(json.load(f))


### PR DESCRIPTION
## Summary
- ignore `manifest.json` when reading snapshot data in `query_server.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488829e92c8321a499d523f33c6f4a