### PR TITLE
Fix snapshot pruning

### DIFF
--- a/snapshot.py
+++ b/snapshot.py
@@ -196,12 +196,11 @@ def load_epoch_schedule(file_path="flare_epoch_schedule.json"):
         return []
 
 def is_snapshot_relevant(snapshot_date, schedule):
-    """Check if a snapshot date falls within any epoch in the schedule."""
-    snapshot_datetime = datetime.datetime.strptime(snapshot_date, "%Y-%m-%d")
+    """Return True if snapshot_date exactly matches an epoch start date."""
+    snapshot_day = datetime.datetime.strptime(snapshot_date, "%Y-%m-%d").date()
     for epoch in schedule:
-        start = datetime.datetime.strptime(epoch["Start (UTC)"], "%Y-%m-%d %H:%M:%S")
-        end = datetime.datetime.strptime(epoch["End (UTC)"], "%Y-%m-%d %H:%M:%S")
-        if start.date() <= snapshot_datetime.date() <= end.date():
+        start = datetime.datetime.strptime(epoch["Start (UTC)"], "%Y-%m-%d %H:%M:%S").date()
+        if snapshot_day == start:
             return True
     return False
 

--- a/tests/test_snapshot_clean.py
+++ b/tests/test_snapshot_clean.py
@@ -36,7 +36,8 @@ def test_is_snapshot_relevant():
         {"Start (UTC)": "2023-02-01 00:00:00", "End (UTC)": "2023-02-05 23:59:59"},
     ]
 
-    assert is_snapshot_relevant("2023-01-03", schedule)
+    assert is_snapshot_relevant("2023-01-01", schedule)
+    assert not is_snapshot_relevant("2023-01-03", schedule)
     assert not is_snapshot_relevant("2023-03-01", schedule)
 
 


### PR DESCRIPTION
## Summary
- only mark a snapshot relevant when it matches an epoch start date
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492926f3b48321ae3a0c102918a750