### PR TITLE
Enable cleaning of docs snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ pytest
 ## Automated Vote Power Snapshots
 
 GitHub Actions runs `current_vote_power.py` every ten minutes. This process keeps `current_vote_power/` and `docs/current_vote_power/` updated with the latest Flare and Songbird vote-power data.
+
+## Cleaning Snapshot Directories
+
+To remove snapshot files that are not aligned with epoch start dates, run
+`clean_snapshots.py` and optionally pass the directory you want to clean:
+
+```bash
+python clean_snapshots.py docs/daily_snapshots
+```
+
+Without an argument it cleans `daily_snapshots/` in the project root. This can
+be used after running the workflow manually if you need to tidy the `docs`
+folder.
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/clean_snapshots.py
+++ b/clean_snapshots.py
@@ -42,8 +42,13 @@ def clean_snapshots(start_dates, snapshot_dir="daily_snapshots"):
                 print(f"Error processing file '{filename}': {e}")
 
 if __name__ == "__main__":
+    import sys
+
+    # allow optional directory argument
+    snapshot_dir = sys.argv[1] if len(sys.argv) > 1 else "daily_snapshots"
+
     # Load epoch start dates
     start_dates = load_epoch_schedule()
 
     # Clean snapshots
-    clean_snapshots(start_dates)
+    clean_snapshots(start_dates, snapshot_dir=snapshot_dir)


### PR DESCRIPTION
## Summary
- allow `clean_snapshots.py` to accept an optional directory path
- document how to use the script to tidy the docs folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492d24cbb08321afac6f1f34da0585