### PR TITLE
Fix pages workflow action version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v1
         with:
           path: docs
       - name: Deploy


### PR DESCRIPTION
## Summary
- update the Github Pages workflow to use the published `v1` of `upload-pages-artifact`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498a9742cc832192b734aaf5487967