### PR TITLE
Fix Pages deployment permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read       # for checkout, build, etc.
   pages: write         # to push the Pages deployment
   id-token: write      # to mint the OIDC token for verification
+  actions: read        # to access the current workflow run
 
 concurrency:
   group: 'pages'
@@ -18,6 +19,9 @@ concurrency:
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add `actions: read` permission for GitHub Pages workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adcf627108321b52def4e250e9a74