### PR TITLE
Fix Pages deployment token

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,23 +11,36 @@ permissions:
   contents: read       # for checkout, build, etc.
   pages: write         # to push the Pages deployment
   id-token: write      # to mint the OIDC token for verification
+  actions: read        # to access the current workflow run
 
 concurrency:
   group: 'pages'
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+      actions: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- refine the workflow to use latest configure-pages action
- explicitly grant permissions in the deploy job and rely on default token

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684adcf627108321b52def4e250e9a74