### PR TITLE
Add lightweight LLM Q&A page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ If you want to experiment with the LLM query endpoint, run the server and visit
 `http://localhost:8000`. The dashboard will be served locally and the prompt bar
 sends questions to `http://localhost:8000/query`.
 
+### Ask the data on GitHub Pages
+
+For a quick demo without running a server, open `docs/qna.html`. This page
+loads `docs/data.json` and sends your questions directly to the OpenAI API.
+Create a `docs/config.js` file (do **not** commit it) with your API key:
+
+```js
+window.OPENAI_API_KEY = "sk-...";
+```
+
+When the file is present locally or uploaded via the GitHub Pages UI, you can
+query the dataset straight from the browser.
+
 
 ## Running Tests
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1,0 +1,38 @@
+{
+  "date": "2025-04-24",
+  "providers": [
+    {
+      "rank": "1",
+      "name": "Bifrost Wallet",
+      "vote_power": 1609987635,
+      "vote_power_locked": 1609987635,
+      "vote_power_pct": "3.59%",
+      "vote_power_pct_locked": "3.61%",
+      "change_24h_pct": "0.10%",
+      "reward_rate": "0.0313",
+      "registered": "Yes"
+    },
+    {
+      "rank": "2",
+      "name": "Flare.Space",
+      "vote_power": 1244755576,
+      "vote_power_locked": 1244755576,
+      "vote_power_pct": "2.78%",
+      "vote_power_pct_locked": "2.76%",
+      "change_24h_pct": "0.47%",
+      "reward_rate": "0.0491",
+      "registered": "Yes"
+    },
+    {
+      "rank": "3",
+      "name": "AlphaOracle",
+      "vote_power": 1115290904,
+      "vote_power_locked": 1115290904,
+      "vote_power_pct": "2.49%",
+      "vote_power_pct_locked": "2.49%",
+      "change_24h_pct": "0.11%",
+      "reward_rate": "0.0543",
+      "registered": "Yes"
+    }
+  ]
+}

--- a/docs/qna.html
+++ b/docs/qna.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Data Q&A</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    textarea, input { width: 100%; font-size: 1rem; margin: .5rem 0; }
+    #answer { white-space: pre-wrap; background: #f1f1f1; padding: 1rem; border-radius: 4px; }
+  </style>
+  <script src="config.js"></script>
+</head>
+<body>
+  <h1>Ask the Data</h1>
+  <p>Loaded dataset: <code>data.json</code></p>
+  <textarea id="question" rows="2" placeholder="e.g. What was the highest vote power?"></textarea>
+  <button onclick="ask()">Ask</button>
+  <div id="answer"></div>
+
+  <script>
+  async function ask() {
+    document.getElementById('answer').textContent = "Thinking…";
+    const data = await fetch('data.json').then(r=>r.text());
+    const prompt = `\nHere is some JSON data:\n${data}\n\nQuestion: ${document.getElementById('question').value}\nAnswer:`;
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + window.OPENAI_API_KEY
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [{role:'user', content: prompt}],
+        temperature: 0
+      })
+    });
+    const {choices} = await res.json();
+    document.getElementById('answer').textContent = choices[0].message.content.trim();
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/qna.html` with minimal HTML/JS calling OpenAI API
- include a small `docs/data.json` sample dataset
- document GitHub Pages LLM demo in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c79274854832183ccfab48593b49f