### PR TITLE
Update provider comparison chart controls

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -87,10 +87,6 @@
             class="w-full p-2 bg-gray-800 border border-gray-700 rounded" />
       </div>
       <div class="flex-1 min-w-[200px]">
-        <label for="multiProviderSelect" class="block font-bold mb-2">Compare Providers:</label>
-        <select id="multiProviderSelect" multiple size="5" class="w-full p-2 bg-gray-800 border border-gray-700 rounded"></select>
-      </div>
-      <div class="flex-1 min-w-[200px]">
           <label class="block font-bold mb-2">
             <input type="checkbox" id="registeredLatestOnly" class="mr-2" />
             Registered in Latest Snapshot Only
@@ -117,7 +113,19 @@
       <div id="chartContainer" class="overflow-x-auto mb-4">
         <canvas id="rewardRateChart" class="w-full h-[400px]"></canvas>
       </div>
-      <div id="multiProviderChartContainer" class="overflow-x-auto mb-4">
+      <div id="multiProviderChartContainer" class="relative overflow-x-auto mb-4">
+        <div id="trendChartControls" class="absolute top-0 left-0 bg-gray-800 bg-opacity-80 p-2 rounded text-xs z-10">
+          <label for="multiProviderSelect" class="block font-bold mb-1">Compare Providers:</label>
+          <select id="multiProviderSelect" multiple size="5" class="mb-2 w-40 p-1 bg-gray-800 border border-gray-700 rounded text-xs"></select>
+          <label for="numTopProviders" class="block font-bold mb-1">Top N:</label>
+          <input id="numTopProviders" type="number" min="1" value="5" class="mb-2 w-20 p-1 bg-gray-800 border border-gray-700 rounded text-xs" />
+          <label for="topKpi" class="block font-bold mb-1">KPI:</label>
+          <select id="topKpi" class="w-40 p-1 bg-gray-800 border border-gray-700 rounded text-xs">
+            <option value="30-day">30-Day Avg</option>
+            <option value="7-day">7-Day Avg</option>
+            <option value="cumulative">Cumulative Avg</option>
+          </select>
+        </div>
         <canvas id="multiProviderChart" class="w-full h-[400px]"></canvas>
       </div>
 
@@ -248,6 +256,9 @@
       Object.keys(stats).forEach(name => {
         const arr = stats[name].rewardRates.map(r => r.rate);
         const n = arr.length;
+        const avg7 = arr.slice(-7).reduce((s, r) => s + r, 0) / Math.min(7, n);
+        const avg30 = arr.slice(-30).reduce((s, r) => s + r, 0) / Math.min(30, n);
+        const avgCum = arr.reduce((s, r) => s + r, 0) / n;
         let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
         arr.forEach((y, i) => {
           const x = i + 1;
@@ -262,6 +273,9 @@
         const stddev = Math.sqrt(variance);
         stats[name].trend = slope;
         stats[name].volatility = stddev;
+        stats[name].avg7 = avg7;
+        stats[name].avg30 = avg30;
+        stats[name].avgCum = avgCum;
       });
 
       const vpData = {};
@@ -300,6 +314,33 @@
       const multiSelect = document.getElementById('multiProviderSelect');
       const names = Object.keys(stats).sort();
       multiSelect.innerHTML = names.map(n => `<option value="${n}">${n}</option>`).join('');
+      updateTopProviders();
+    }
+
+    function updateTopProviders() {
+      const kpi = document.getElementById('topKpi').value;
+      const num = parseInt(document.getElementById('numTopProviders').value) || 5;
+      const names = Object.keys(providerStats);
+      const sorted = names.sort((a, b) => {
+        const getAvg = (name) => {
+          switch (kpi) {
+            case '7-day':
+              return providerStats[name].avg7 || 0;
+            case 'cumulative':
+              return providerStats[name].avgCum || 0;
+            default:
+              return providerStats[name].avg30 || 0;
+          }
+        };
+        return getAvg(b) - getAvg(a);
+      });
+
+      const top = sorted.slice(0, num);
+      const select = document.getElementById('multiProviderSelect');
+      Array.from(select.options).forEach(opt => {
+        opt.selected = top.includes(opt.value);
+      });
+      renderMultiProviderChart();
     }
 
     function getFilteredProviders() {
@@ -677,10 +718,10 @@
 
     function renderMultiProviderChart() {
       const select = document.getElementById('multiProviderSelect');
-      const selected = Array.from(select.selectedOptions).slice(0, 5).map(o => o.value);
+      const selected = Array.from(select.selectedOptions).map(o => o.value);
       const dates = window.flareSnapshots.map(s => s.date);
       const datasets = selected.map((name, idx) => {
-        const colors = ['orange', 'blue', 'purple', 'green', 'red'];
+        const colors = ['orange', 'blue', 'purple', 'green', 'red', 'yellow', 'cyan', 'magenta', 'lime', 'teal'];
         const data = dates.map(d => {
           const snap = window.flareSnapshots.find(s => s.date === d);
           const p = snap?.providers.find(pr => pr.name === name);
@@ -834,6 +875,8 @@
     });
     document.getElementById('timeframe').addEventListener('change', debouncedRenderChart);
     document.getElementById('multiProviderSelect').addEventListener('change', renderMultiProviderChart);
+    document.getElementById('numTopProviders').addEventListener('input', updateTopProviders);
+    document.getElementById('topKpi').addEventListener('change', updateTopProviders);
 
     // Query functionality disabled when no LLM backend is used.
     async function sendQuery() {


### PR DESCRIPTION
## Summary
- move provider comparison selector into the trends chart
- allow selecting KPI and number of top providers
- compute averages for top-provider selection
- adjust chart rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685290c5429c8321808c6c42a0ee9668