### PR TITLE
Add names-only filter box and restore intraday charts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,6 +76,13 @@
         <div id="currentVpChartContainer" style="width: 100%;"></div>
         <input id="currentVpRange" type="range" min="0" max="0" value="0" class="w-full mt-2" />
       </div>
+  </section>
+
+    <section id="nameFilterSection" class="border-4 border-gray-700 rounded p-4 mb-4">
+      <label class="font-bold">
+        <input type="checkbox" id="namedOnly" class="mr-2" checked />
+        Names Only
+      </label>
     </section>
 
     <!-- Multi-provider chart and table -->
@@ -309,18 +316,25 @@
         }
       });
 
-      providerStats = stats;
+        providerStats = stats;
+        updateMultiProviderOptions();
+      }
 
-      const multiSelect = document.getElementById('multiProviderSelect');
-      const names = Object.keys(stats).sort();
-      multiSelect.innerHTML = names.map(n => `<option value="${n}">${n}</option>`).join('');
-      updateTopProviders();
-    }
+      function updateMultiProviderOptions() {
+        const multiSelect = document.getElementById('multiProviderSelect');
+        const namesOnly = document.getElementById('namedOnly').checked;
+        const names = Object.keys(providerStats)
+          .filter(n => !(namesOnly && n.startsWith('0x')))
+          .sort();
+        multiSelect.innerHTML = names.map(n => `<option value="${n}">${n}</option>`).join('');
+        updateTopProviders();
+      }
 
     function updateTopProviders() {
       const kpi = document.getElementById('topKpi').value;
       const num = parseInt(document.getElementById('numTopProviders').value) || 5;
-      const names = Object.keys(providerStats);
+        const namesOnly = document.getElementById('namedOnly').checked;
+        const names = Object.keys(providerStats).filter(n => !(namesOnly && n.startsWith('0x')));
       const sorted = names.sort((a, b) => {
         const getAvg = (name) => {
           switch (kpi) {
@@ -346,6 +360,7 @@
     function getFilteredProviders() {
       const registeredOnly = document.getElementById('registeredOnly').checked;
       const registeredLatestOnly = document.getElementById('registeredLatestOnly').checked;
+      const namesOnly = document.getElementById('namedOnly').checked;
       let latestSnapshot = window.flareSnapshots[window.flareSnapshots.length - 1];
       let registeredInLatest = new Set();
       if (latestSnapshot) {
@@ -365,6 +380,7 @@
           const isRegisteredLatest = registeredInLatest.has(provider.name);
           if (registeredOnly && !isRegistered) return false;
           if (registeredLatestOnly && !isRegisteredLatest) return false;
+          if (namesOnly && provider.name.startsWith('0x')) return false;
           return true;
         }).map(provider => ({
           ...provider,
@@ -374,11 +390,13 @@
       return filtered;
     }
 
-    function getFilteredSongbirdProviders() {
-      const providersOverLimit = getProvidersOverLimitCombined();
+      function getFilteredSongbirdProviders() {
+        const providersOverLimit = getProvidersOverLimitCombined();
+        const namesOnly = document.getElementById('namedOnly').checked;
       const filtered = window.songbirdSnapshots.flatMap(snapshot =>
         snapshot.providers.filter(provider => {
           if (providersOverLimit.has(provider.SGB_provider)) return false;
+          if (namesOnly && provider.SGB_provider.startsWith('0x')) return false;
           return true;
         }).map(provider => ({
           ...provider,
@@ -872,6 +890,14 @@
     document.getElementById('registeredOnly').addEventListener('change', () => {
       debouncedRenderChart();
       debouncedRenderTable();
+    });
+    document.getElementById('namedOnly').addEventListener('change', () => {
+      debouncedRenderChart();
+      debouncedRenderTable();
+      renderSingleProviderChart();
+      renderCurrentVoteChart();
+      updateMultiProviderOptions();
+      renderMultiProviderChart();
     });
     document.getElementById('timeframe').addEventListener('change', debouncedRenderChart);
     document.getElementById('multiProviderSelect').addEventListener('change', renderMultiProviderChart);


### PR DESCRIPTION
## Summary
- move `Names Only` checkbox into its own section and default to checked
- filter provider lists for all charts and tables when checked
- refresh provider selections on toggle so missing charts reappear

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852abf64a488321a1dae3793e7791d1