### PR TITLE
Add export-history workflow

### DIFF
--- a/.github/workflows/export-history.yml
+++ b/.github/workflows/export-history.yml
@@ -1,0 +1,34 @@
+name: Export Delegation History
+
+on:
+  workflow_dispatch:
+
+jobs:
+  export-history:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run export history script
+        run: python export_history.py
+
+      - name: Commit and push results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@users.noreply.github.com'
+          git add history/
+          git commit -m "Export delegation history" || echo "No changes"
+          git push


### PR DESCRIPTION
## Summary
- add GitHub workflow to export delegation history via `export_history.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68556ed33f9c8321a976eb9a0d0e5e9e