### PR TITLE
Fix delegation history export

### DIFF
--- a/.github/workflows/export-history.yml
+++ b/.github/workflows/export-history.yml
@@ -1,0 +1,38 @@
+name: Export Delegation History
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  export-history:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run export history script
+        env:
+          FLARE_GRAPHQL_URL: https://flare-explorer.flare.network/graphql
+        run: python export_history.py
+
+      - name: Commit and push results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@users.noreply.github.com'
+          git add history/
+          git commit -m "Export delegation history" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ also traverse these folders.
 
 ## Exporting Delegation History
 
-Use `export_history.py` to fetch all delegation events from block `0` onwards.
-The script queries the configured RPC endpoint and stores the logs in
-`history/<network>_delegations.json`.
+Use `export_history.py` to fetch all delegation events via the public GraphQL
+endpoint. Results are stored in `history/<network>_delegations.json`.
+The workflow `export-history.yml` runs this script every day so the dataset
+stays up to date.
 
 ```bash
-python export_history.py    # uses FLARE_RPC_URL if set
+python export_history.py    # uses FLARE_GRAPHQL_URL if set
 ```
 
 This dataset can be used for deeper analysis of vote power changes over time.

--- a/export_history.py
+++ b/export_history.py
@@ -1,19 +1,48 @@
 import json
 import os
-from flare_rpc import connect, get_all_delegation_logs
+import requests
+
+DEFAULT_GRAPHQL_URL = "https://flare-explorer.flare.network/graphql"
+
+QUERY = """
+query($first: Int!, $skip: Int!) {
+  delegationChangedEvents(first: $first, skip: $skip) {
+    id
+    delegator
+    delegatee
+    amount
+    blockNumber
+    transactionHash
+  }
+}
+"""
+
+
+def fetch_all_delegations(url: str, first: int = 1000) -> list:
+    """Fetch all delegation change events via GraphQL."""
+    delegations = []
+    skip = 0
+    while True:
+        payload = {"query": QUERY, "variables": {"first": first, "skip": skip}}
+        resp = requests.post(url, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json().get("data", {}).get("delegationChangedEvents", [])
+        if not data:
+            break
+        delegations.extend(data)
+        skip += first
+    return delegations
 
 
 def main(network: str = "flare") -> None:
-    w3 = connect()
-    logs = get_all_delegation_logs(w3)
+    url = os.getenv("FLARE_GRAPHQL_URL", DEFAULT_GRAPHQL_URL)
+    logs = fetch_all_delegations(url)
     out_dir = os.path.join("history")
     os.makedirs(out_dir, exist_ok=True)
     path = os.path.join(out_dir, f"{network}_delegations.json")
-    # convert to plain dicts to avoid serialization issues
-    serializable = [{k: log[k] for k in log} for log in logs]
     with open(path, "w") as f:
-        json.dump(serializable, f, indent=2)
-    print(f"Saved {len(serializable)} logs to {path}")
+        json.dump(logs, f, indent=2)
+    print(f"Saved {len(logs)} logs to {path}")
 
 
 if __name__ == "__main__":

--- a/flare_rpc.py
+++ b/flare_rpc.py
@@ -78,8 +78,12 @@ FTSO_MANAGER_ABI = [
 
 
 # Event signatures for delegation events
-DELEGATED_TOPIC = Web3.keccak(text="VotingPowerDelegated(address,address,uint256)").hex()
-UNDELEGATED_TOPIC = Web3.keccak(text="VotingPowerUndelegated(address,address,uint256)").hex()
+DELEGATED_TOPIC = "0x" + Web3.keccak(
+    text="VotingPowerDelegated(address,address,uint256)"
+).hex()
+UNDELEGATED_TOPIC = "0x" + Web3.keccak(
+    text="VotingPowerUndelegated(address,address,uint256)"
+).hex()
 
 
 


### PR DESCRIPTION
## Summary
- switch `export_history.py` to use Blockscout GraphQL
- document GraphQL-based export in README
- set GraphQL endpoint in export-history workflow
- run export-history workflow daily

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68556ed33f9c8321a976eb9a0d0e5e9e