### PR TITLE
Fix export_history error on invalid JSON

### DIFF
--- a/export_history.py
+++ b/export_history.py
@@ -1,6 +1,7 @@
 import json
 import os
 import requests
+from requests.exceptions import JSONDecodeError
 
 DEFAULT_GRAPHQL_URL = "https://flare-explorer.flare.network/graphql"
 
@@ -26,7 +27,12 @@ def fetch_all_delegations(url: str, first: int = 1000) -> list:
         payload = {"query": QUERY, "variables": {"first": first, "skip": skip}}
         resp = requests.post(url, json=payload, timeout=30)
         resp.raise_for_status()
-        data = resp.json().get("data", {}).get("delegationChangedEvents", [])
+        try:
+            json_resp = resp.json()
+        except JSONDecodeError as exc:
+            snippet = resp.text[:200]
+            raise RuntimeError(f"Failed to decode JSON from {url}: {snippet!r}") from exc
+        data = json_resp.get("data", {}).get("delegationChangedEvents", [])
         if not data:
             break
         delegations.extend(data)

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -1,0 +1,32 @@
+import sys
+import types
+import pytest
+
+# Create a stub requests module so export_history imports it
+requests = types.ModuleType("requests")
+class DummyJSONDecodeError(Exception):
+    pass
+exceptions_module = types.ModuleType("requests.exceptions")
+exceptions_module.JSONDecodeError = DummyJSONDecodeError
+requests.exceptions = exceptions_module
+requests.post = lambda *a, **k: None
+sys.modules.setdefault("requests", requests)
+sys.modules.setdefault("requests.exceptions", exceptions_module)
+
+import export_history
+
+class DummyResponse:
+    def __init__(self, text="bad"):
+        self.text = text
+    def raise_for_status(self):
+        pass
+    def json(self):
+        raise DummyJSONDecodeError("bad")
+
+
+def test_fetch_all_delegations_bad_json(monkeypatch):
+    def fake_post(url, json=None, timeout=0):
+        return DummyResponse("<html>error</html>")
+    monkeypatch.setattr(export_history.requests, "post", fake_post)
+    with pytest.raises(RuntimeError):
+        export_history.fetch_all_delegations("http://example.com")


### PR DESCRIPTION
## Summary
- guard against invalid JSON in export_history
- add a regression test for handling bad JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c9cfaaa48321a75d7fc1f96531af