### PR TITLE
Fix GraphQL URL and README

### DIFF
--- a/.github/workflows/export-history.yml
+++ b/.github/workflows/export-history.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run export history script
 
         env:
-          FLARE_GRAPHQL_URL: https://flare-explorer.flare.network/graphiql
+          FLARE_GRAPHQL_URL: https://flare-explorer.flare.network/graphql
 
 
         run: python export_history.py

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ also traverse these folders.
 
 Use `export_history.py` to fetch all delegation events via the public GraphQL
 endpoint. Results are stored in `history/<network>_delegations.json`.
+Set `FLARE_GRAPHQL_URL` to the GraphQL endpoint (e.g.
+`https://flare-explorer.flare.network/graphql`) if it differs from the default.
+The endpoint returns a 404 page when opened in a browser because it only
+accepts POST requests. Use `curl` or `export_history.py` to send a GraphQL
+query, for example:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"query":"{ __typename }"}' \
+     https://flare-explorer.flare.network/graphql
+```
 
 
 ```bash

--- a/export_history.py
+++ b/export_history.py
@@ -42,6 +42,9 @@ def fetch_all_delegations(url: str, first: int = 1000) -> list:
 
 def main(network: str = "flare") -> None:
     url = os.getenv("FLARE_GRAPHQL_URL", DEFAULT_GRAPHQL_URL)
+    if url.endswith("/graphiql"):
+        url = url[: -len("graphiql")] + "graphql"
+    print(f"Using GraphQL endpoint: {url}")
     logs = fetch_all_delegations(url)
     out_dir = os.path.join("history")
     os.makedirs(out_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- point export-history workflow to the `/graphql` endpoint
- clarify usage of `FLARE_GRAPHQL_URL` in README
- auto-correct `FLARE_GRAPHQL_URL` that ends with `/graphiql`
- document that `/graphql` must be POSTed to and show a curl example
- log which GraphQL endpoint is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cc537ca48321b1b095983369bea0