### PR TITLE
Add flaremetrics scraping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,13 @@ Use `export_history.py` to fetch all delegation events via the public GraphQL
 endpoint. Results are stored in `history/<network>_delegations.json`.
 Set `FLARE_GRAPHQL_URL` to the GraphQL endpoint (e.g.
 `https://flare-explorer.flare.network/graphql`) if it differs from the default.
-If the `/graphql` path returns a 404 error, the script automatically falls back
-to `/graphiql`. The endpoint may return a 404 page when opened in a browser
-because it only accepts POST requests. Use `curl` or `export_history.py` to send
-a GraphQL query, for example:
+If GraphQL fails (for example due to a 404 or invalid response) the script
+first tries to scrape data from `flaremetrics.io`. If that also fails it
+falls back to querying the RPC endpoint directly. When the `/graphql` path
+specifically returns a 404 error, the code first retries the `/graphiql`
+path. The endpoint may return a 404 page when opened in a browser because it
+only accepts POST requests. Use `curl` or `export_history.py` to send a
+GraphQL query, for example:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/export_history.py
+++ b/export_history.py
@@ -1,7 +1,10 @@
 import json
 import os
+import re
 import requests
 from requests.exceptions import JSONDecodeError, HTTPError
+from html import unescape
+from flare_rpc import connect, get_all_delegation_logs
 
 DEFAULT_GRAPHQL_URL = "https://flare-explorer.flare.network/graphql"
 
@@ -19,7 +22,7 @@ query($first: Int!, $skip: Int!) {
 """
 
 
-def fetch_all_delegations(url: str, first: int = 1000) -> list:
+def fetch_all_delegations_graphql(url: str, first: int = 1000) -> list:
     """Fetch all delegation change events via GraphQL."""
     delegations = []
     skip = 0
@@ -50,12 +53,58 @@ def fetch_all_delegations(url: str, first: int = 1000) -> list:
     return delegations
 
 
+def fetch_delegations_rpc() -> list:
+    """Fetch delegation change logs via RPC as a fallback."""
+    w3 = connect()
+    logs = get_all_delegation_logs(w3)
+    return [{k: log[k] for k in log} for log in logs]
+
+
+def scrape_delegations_flaremetrics(network: str = "flare") -> list:
+    """Scrape delegation events from flaremetrics.io."""
+    url = f"https://flaremetrics.io/{network}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    html = resp.text
+    rows = []
+    for row_html in re.findall(r"<tr>(.*?)</tr>", html, re.DOTALL):
+        cols = re.findall(r"<td.*?>(.*?)</td>", row_html, re.DOTALL)
+        rows.append([unescape(re.sub("<.*?>", "", c)).strip() for c in cols])
+
+    delegations = []
+    for cols in rows:
+        if len(cols) >= 5:
+            delegations.append(
+                {
+                    "delegator": cols[0],
+                    "delegatee": cols[1],
+                    "amount": cols[2],
+                    "blockNumber": cols[3],
+                    "transactionHash": cols[4],
+                }
+            )
+    return delegations
+
+
+def fetch_all_delegations(url: str, first: int = 1000, network: str = "flare") -> list:
+    """Fetch delegation events with multiple fallbacks."""
+    try:
+        return fetch_all_delegations_graphql(url, first=first)
+    except Exception as exc:
+        print(f"GraphQL fetch failed: {exc}; trying flaremetrics")
+        try:
+            return scrape_delegations_flaremetrics(network)
+        except Exception as exc2:
+            print(f"Flaremetrics scrape failed: {exc2}; falling back to RPC")
+            return fetch_delegations_rpc()
+
+
 def main(network: str = "flare") -> None:
     url = os.getenv("FLARE_GRAPHQL_URL", DEFAULT_GRAPHQL_URL)
     if url.endswith("/graphiql"):
         url = url[: -len("graphiql")] + "graphql"
     print(f"Using GraphQL endpoint: {url}")
-    logs = fetch_all_delegations(url)
+    logs = fetch_all_delegations(url, network=network)
     out_dir = os.path.join("history")
     os.makedirs(out_dir, exist_ok=True)
     path = os.path.join(out_dir, f"{network}_delegations.json")

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -14,6 +14,7 @@ class DummyHTTPError(Exception):
 exceptions_module.HTTPError = DummyHTTPError
 requests.exceptions = exceptions_module
 requests.post = lambda *a, **k: None
+requests.get = lambda *a, **k: None
 sys.modules.setdefault("requests", requests)
 sys.modules.setdefault("requests.exceptions", exceptions_module)
 
@@ -32,12 +33,30 @@ class DummyResponse:
         raise DummyJSONDecodeError("bad")
 
 
-def test_fetch_all_delegations_bad_json(monkeypatch):
+def test_fetch_all_delegations_bad_json_scrape(monkeypatch):
     def fake_post(url, json=None, timeout=0):
         return DummyResponse("<html>error</html>")
+
+    html = (
+        "<table><tbody><tr><td>a</td><td>b</td><td>1</td><td>2</td><td>h</td></tr></tbody></table>"
+    )
+
     monkeypatch.setattr(export_history.requests, "post", fake_post)
-    with pytest.raises(RuntimeError):
-        export_history.fetch_all_delegations("http://example.com")
+    monkeypatch.setattr(export_history.requests, "get", lambda url, timeout=0: DummyResponse(html))
+    monkeypatch.setattr(export_history, "connect", lambda: (_ for _ in ()).throw(AssertionError("connect should not be called")))
+    monkeypatch.setattr(export_history, "get_all_delegation_logs", lambda w3: (_ for _ in ()).throw(AssertionError("logs should not be called")))
+
+    result = export_history.fetch_all_delegations("http://example.com", network="flare")
+
+    assert result == [
+        {
+            "delegator": "a",
+            "delegatee": "b",
+            "amount": "1",
+            "blockNumber": "2",
+            "transactionHash": "h",
+        }
+    ]
 
 
 def test_fallback_to_graphiql(monkeypatch):
@@ -50,6 +69,37 @@ def test_fallback_to_graphiql(monkeypatch):
         return DummyResponse('{"data":{"delegationChangedEvents":[]}}', status_code=200)
 
     monkeypatch.setattr(export_history.requests, "post", fake_post)
+    monkeypatch.setattr(export_history, "connect", lambda: (_ for _ in ()).throw(AssertionError("connect should not be called")))
+    monkeypatch.setattr(export_history, "get_all_delegation_logs", lambda w3: (_ for _ in ()).throw(AssertionError("logs should not be called")))
+
     result = export_history.fetch_all_delegations("http://example.com/graphql", first=1)
     assert result == []
     assert calls == ["http://example.com/graphql", "http://example.com/graphiql"]
+
+
+def test_scrape_failure_fallback_to_rpc(monkeypatch):
+    def fake_post(url, json=None, timeout=0):
+        return DummyResponse("bad html")
+
+    def fake_get(url, timeout=0):
+        raise export_history.requests.exceptions.HTTPError()
+
+    rpc_called = {}
+
+    def fake_connect():
+        rpc_called["connect"] = True
+        return "w3"
+
+    def fake_logs(w3):
+        rpc_called["logs"] = True
+        return [{"log": 1}]
+
+    monkeypatch.setattr(export_history.requests, "post", fake_post)
+    monkeypatch.setattr(export_history.requests, "get", fake_get)
+    monkeypatch.setattr(export_history, "connect", fake_connect)
+    monkeypatch.setattr(export_history, "get_all_delegation_logs", fake_logs)
+
+    result = export_history.fetch_all_delegations("http://example.com", network="flare")
+
+    assert result == [{"log": 1}]
+    assert rpc_called == {"connect": True, "logs": True}


### PR DESCRIPTION
## Summary
- fall back to flaremetrics scraping when GraphQL export fails
- keep RPC as last resort if scraping also fails
- document new fallback in README
- update tests for scraping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f6c3d2488321ac921541ffc488f8