### PR TITLE
Remove RPC fallback from export_history

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ endpoint. Results are stored in `history/<network>_delegations.json`.
 Set `FLARE_GRAPHQL_URL` to the GraphQL endpoint (e.g.
 `https://flare-explorer.flare.network/graphql`) if it differs from the default.
 If GraphQL fails (for example due to a 404 or invalid response) the script
-first tries to scrape data from `flaremetrics.io`. If that also fails it
-falls back to querying the RPC endpoint directly. When the `/graphql` path
+falls back to scraping data from `flaremetrics.io`. When the `/graphql` path
 specifically returns a 404 error, the code first retries the `/graphiql`
 path. The endpoint may return a 404 page when opened in a browser because it
 only accepts POST requests. Use `curl` or `export_history.py` to send a

--- a/export_history.py
+++ b/export_history.py
@@ -4,7 +4,7 @@ import re
 import requests
 from requests.exceptions import JSONDecodeError, HTTPError
 from html import unescape
-from flare_rpc import connect, get_all_delegation_logs
+
 
 DEFAULT_GRAPHQL_URL = "https://flare-explorer.flare.network/graphql"
 
@@ -53,13 +53,6 @@ def fetch_all_delegations_graphql(url: str, first: int = 1000) -> list:
     return delegations
 
 
-def fetch_delegations_rpc() -> list:
-    """Fetch delegation change logs via RPC as a fallback."""
-    w3 = connect()
-    logs = get_all_delegation_logs(w3)
-    return [{k: log[k] for k in log} for log in logs]
-
-
 def scrape_delegations_flaremetrics(network: str = "flare") -> list:
     """Scrape delegation events from flaremetrics.io."""
     url = f"https://flaremetrics.io/{network}"
@@ -92,11 +85,7 @@ def fetch_all_delegations(url: str, first: int = 1000, network: str = "flare") -
         return fetch_all_delegations_graphql(url, first=first)
     except Exception as exc:
         print(f"GraphQL fetch failed: {exc}; trying flaremetrics")
-        try:
-            return scrape_delegations_flaremetrics(network)
-        except Exception as exc2:
-            print(f"Flaremetrics scrape failed: {exc2}; falling back to RPC")
-            return fetch_delegations_rpc()
+        return scrape_delegations_flaremetrics(network)
 
 
 def main(network: str = "flare") -> None:


### PR DESCRIPTION
## Summary
- stop importing RPC helpers
- remove RPC fallback from `export_history.fetch_all_delegations`
- drop unused RPC helper
- update README documentation
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685900c910b48321b314ab813d46f530