### PR TITLE
Fix manifest name handling and update workflow

### DIFF
--- a/.github/workflows/daily-snapshot.yml
+++ b/.github/workflows/daily-snapshot.yml
@@ -40,4 +40,5 @@ jobs:
           git config --global user.email 'github-actions@users.noreply.github.com'
           git add daily_snapshots/ docs/daily_snapshots/
           git commit -m "Daily Flaremetrics snapshot $(date +'%Y-%m-%d')" || echo "No changes to commit"
+          git pull --rebase origin main
           git push

--- a/clean_snapshots.py
+++ b/clean_snapshots.py
@@ -1,6 +1,7 @@
 import os
 import json
 import datetime
+import re
 
 def load_epoch_schedule(file_path="flare_epoch_schedule.json"):
     """Load the epoch schedule from a JSON file and extract only the start dates."""
@@ -47,9 +48,14 @@ def clean_snapshots(
         except Exception:
             pass
 
+    date_pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
     for root, _, files in os.walk(snapshot_dir):
         for filename in files:
+            if filename == "manifest.json":
+                continue
             if not filename.endswith(".json"):
+                continue
+            if not date_pattern.search(filename):
                 continue
             rel_path = os.path.relpath(os.path.join(root, filename), snapshot_dir)
             snapshot_date = filename.split("_")[-1].replace(".json", "")

--- a/snapshot.py
+++ b/snapshot.py
@@ -293,9 +293,14 @@ def clean_snapshots(
         except Exception:
             pass
 
+    date_pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
     for root, _, files in os.walk(snapshot_dir):
         for filename in files:
+            if filename == "manifest.json":
+                continue
             if not filename.endswith(".json"):
+                continue
+            if not date_pattern.search(filename):
                 continue
             rel_path = os.path.relpath(os.path.join(root, filename), snapshot_dir)
             snapshot_date = filename.split("_")[-1].replace(".json", "")


### PR DESCRIPTION
## Summary
- avoid parsing `manifest.json` like a dated snapshot
- skip files without a `YYYY-MM-DD` date in name when cleaning snapshots
- rebase before pushing results in daily snapshot workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593343bac883219d833cd479450251